### PR TITLE
added login_required decorator

### DIFF
--- a/monolith/auth.py
+++ b/monolith/auth.py
@@ -1,6 +1,7 @@
 import functools
 from flask_login import current_user, LoginManager
 from monolith.database import User
+from flask import redirect
 
 
 login_manager = LoginManager()
@@ -22,3 +23,12 @@ def load_user(user_id):
     if user is not None:
         user._authenticated = True
     return user
+
+
+def login_required(func):
+    @functools.wraps(func)
+    def _login_required(*args, **kw):
+        if current_user is not None and current_user.is_authenticated:
+            return func(*args, **kw)
+        return redirect('/')
+    return _login_required


### PR DESCRIPTION
Added `@login_required` decorator in `monolith/auth.py` to automate redirection to `index.html` if a user is NOT authenticated/logged.

## How to use
Decorate the function in which you render the html page that has to be protected against NOT authenticated/logged users.

Example:
```
...
from monolith.auth import login_required
...
@users.route('/users')
@login_required
def _users():
    users = db.session.query(User)
    return render_template("users.html", users=users)
```
With this decorator, if a user not authenticated or not logged tries to reach `/users.html`, he is redirected to `/index.html`.