### PR TITLE
Add a decorator to check if the user token is still valid or not

### DIFF
--- a/monolith/auth.py
+++ b/monolith/auth.py
@@ -32,3 +32,19 @@ def login_required(func):
             return func(*args, **kw)
         return redirect('/')
     return _login_required
+
+
+def strava_token_required(func):
+    @functools.wraps(func)
+    def _strava_token_required(*args, **kw):
+        try:
+            func(*args, **kw)
+        except exc.AccessUnauthorized:
+            if current_user is not None and hasattr(current_user, 'id'):
+                q = db.session.query(User).filter(User.id == current_user.id)
+                user = q.first()
+                user.strava_token = None
+                db.session.add(user)
+                db.session.commit()
+                return redirect('/')
+    return _strava_token_required


### PR DESCRIPTION
Added `@strava_token_required` decorator in `monolith/auth.py` to automatically catch `stravalib.exc.AccessUnauthorized` exception raised if the user removed the access from [Strava](https://www.strava.com/settings/apps) and automatically redirect the user to the `index.html` page where he can request another access token from Strava

# How To Use
Decorate the function in which you use the `stravalib.Client` class to make requests to the Strava API.

Example:

    ...
    from monolith.auth import strava_token_required
    ...
    @strava.route('/fetch')
    @strava_token_required
    def fetch_runs():
        res = fetch_all_runs.delay()
        res.wait()
        return jsonify(res.result)

with this decorator if the stored access token has been removed by the user instead of a very angry **500 - internal server error** when the user tries to go to `/fetch` he will be redirected to `/index.html` where he will be able to request another strava_token
