### PR TITLE
Celery periodic Task

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,10 @@ Then, open another shell and run::
 This will run a celery microservice that can fetch runs.
 To invoke it, visit http://127.0.0.1:5000/fetch.
 
+    $ celery -A monolith.background worker -B
+
+This will run celery microservice with a periodic task to fetch runs.
+
 Once the runs are retrieved, you should see your last ten runs
 on http://127.0.0.1:5000
 

--- a/monolith/background.py
+++ b/monolith/background.py
@@ -2,23 +2,43 @@ from celery import Celery
 from stravalib import Client
 from monolith.database import db, User, Run
 
+"""
+    To have the periodic task running runs celery with
+    
+    celery -A monolith.background worker -B
+
+"""
+
 BACKEND = BROKER = 'redis://localhost:6379'
 celery = Celery(__name__, backend=BACKEND, broker=BROKER)
 
 _APP = None
 
 
-@celery.task
-def fetch_all_runs():
+@celery.on_after_configure.connect
+def set_up_tasks(sender, **kwargs):
+    sender.add_periodic_task(3600.00, fetch_all_runs, name='fetch_all_the_runs every hour')
+    # sender.add_periodic_task(10.00, fetch_all_runs.s(), name='fetch_all_the_runs every hour')
+    # use this to test the function
+
+
+def create_context():
     global _APP
     # lazy init
     if _APP is None:
         from monolith.app import create_app
         app = create_app()
         db.init_app(app)
+        _APP = app
     else:
         app = _APP
+    return app
 
+
+@celery.task
+def fetch_all_runs():
+
+    app = create_context()
     runs_fetched = {}
 
     with app.app_context():
@@ -27,9 +47,7 @@ def fetch_all_runs():
             if user.strava_token is None:
                 continue
             print('Fetching Strava for %s' % user.email)
-            runs_fetched[user.id] = fetch_runs(user)
-
-    return runs_fetched
+            runs_fetched[user.id] = fetch_runs(user.id)
 
 
 def activity2run(user, activity):
@@ -48,19 +66,22 @@ def activity2run(user, activity):
     return run
 
 
-def fetch_runs(user):
-    client = Client(access_token=user.strava_token)
-    runs = 0
+@celery.task
+def fetch_runs(id):
+    app = create_context()
+    with app.app_context():
+        q = db.session.query(User).filter(User.id == id)
+        user = q.first()
+        client = Client(access_token=user.strava_token)
+        runs = 0
+        for activity in client.get_activities(limit=10):
+            if activity.type != 'Run':
+                continue
+            q = db.session.query(Run).filter(Run.strava_id == activity.id)
+            run = q.first()
+            if run is None:
+                db.session.add(activity2run(user, activity))
+                runs += 1
 
-    for activity in client.get_activities(limit=10):
-        if activity.type != 'Run':
-            continue
-        q = db.session.query(Run).filter(Run.strava_id == activity.id)
-        run = q.first()
-
-        if run is None:
-            db.session.add(activity2run(user, activity))
-            runs += 1
-
-    db.session.commit()
-    return runs
+        db.session.commit()
+        return runs

--- a/monolith/background.py
+++ b/monolith/background.py
@@ -17,8 +17,8 @@ _APP = None
 
 @celery.on_after_configure.connect
 def set_up_tasks(sender, **kwargs):
-    # sender.add_periodic_task(3600.00, fetch_all_runs, name='fetch_all_the_runs every hour')
-    sender.add_periodic_task(10.00, fetch_all_runs.s(), name='fetch_all_the_runs every hour')
+    sender.add_periodic_task(3600.00, fetch_all_runs, name='fetch_all_the_runs every hour')
+    # sender.add_periodic_task(10.00, fetch_all_runs.s(), name='fetch_all_the_runs every hour')
     # use this to test the function
 
 
@@ -40,14 +40,22 @@ def fetch_all_runs():
 
     app = create_context()
     runs_fetched = {}
-
     with app.app_context():
         q = db.session.query(User)
         for user in q:
             if user.strava_token is None:
                 continue
             print('Fetching Strava for %s' % user.email)
-            runs_fetched[user.id] = fetch_runs_alternative(user)
+            runs_fetched[user.id] = fetch_runs(user)
+
+
+@celery.task
+def fetch_runs_for_user(id):
+    app = create_context()
+    with app.app_context():
+        q = db.session.query(User).filter(User.id == id)
+        user = q.first()
+        return fetch_runs(user)
 
 
 def activity2run(user, activity):
@@ -66,9 +74,7 @@ def activity2run(user, activity):
     return run
 
 
-def fetch_runs_alternative(user):
-    # q = db.session.query(User).filter(User.id == user.id)
-    # user = q.first()
+def fetch_runs(user):
     client = Client(access_token=user.strava_token)
     runs = 0
     for activity in client.get_activities(limit=10):
@@ -82,24 +88,3 @@ def fetch_runs_alternative(user):
 
     db.session.commit()
     return runs
-
-
-@celery.task
-def fetch_runs(id):
-    app = create_context()
-    with app.app_context():
-        q = db.session.query(User).filter(User.id == id)
-        user = q.first()
-        client = Client(access_token=user.strava_token)
-        runs = 0
-        for activity in client.get_activities(limit=10):
-            if activity.type != 'Run':
-                continue
-            q = db.session.query(Run).filter(Run.strava_id == activity.id)
-            run = q.first()
-            if run is None:
-                db.session.add(activity2run(user, activity))
-                runs += 1
-
-        db.session.commit()
-        return runs

--- a/monolith/views/strava.py
+++ b/monolith/views/strava.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, request, redirect
-from monolith.background import fetch_runs
+from monolith.background import fetch_runs_for_user
 from monolith.auth import strava_token_required, login_required
 from flask_login import current_user
 
@@ -10,6 +10,6 @@ strava = Blueprint('strava', __name__)
 @strava_token_required
 @login_required
 def fetch():
-    res = fetch_runs.delay(current_user.id)
+    res = fetch_runs_for_user.delay(current_user.id)
     res.wait()
     return request.referrer or redirect('/')

--- a/monolith/views/strava.py
+++ b/monolith/views/strava.py
@@ -1,14 +1,15 @@
-from flask import Blueprint, jsonify
-from monolith.background import fetch_all_runs
-from monolith.auth import strava_token_required
-
+from flask import Blueprint, request, redirect
+from monolith.background import fetch_runs
+from monolith.auth import strava_token_required, login_required
+from flask_login import current_user
 
 strava = Blueprint('strava', __name__)
 
 
 @strava.route('/fetch')
 @strava_token_required
-def fetch_runs():
-    res = fetch_all_runs.delay()
+@login_required
+def fetch():
+    res = fetch_runs.delay(current_user.id)
     res.wait()
-    return jsonify(res.result)
+    return request.referrer or redirect('/')


### PR DESCRIPTION
# Let's make Celery Periodic

Now celery periodically fetches from [Strava](www.strava.com) all the runs for the registered users,

to launch celery with a periodic task, run it as:

    $ celery -A monolith.background worker -B

Now when we go to `/fetch` the link will fetch all the new runs for the current logged user then redirect to the previous page or to `/`

