### PR TITLE
Add support to Travis-CI and Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python: 3.6
+env:
+ - TOX_ENV=py36
+install:
+ - pip install tox
+script:
+ - tox -e $TOX_ENV

--- a/tests/test_trevis-ci.py
+++ b/tests/test_trevis-ci.py
@@ -1,0 +1,6 @@
+import unittest
+
+class Test(unittest.TestCase):
+
+    def test(self):
+        self.assertTrue(True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py36
+
+[testenv]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+deps = pytest
+       pytest-cov
+       coveralls
+       -rrequirements.txt
+
+commands = 
+    pytest --cov-config .coveragerc --cov beepbeep-monolith/tests
+    - coveralls


### PR DESCRIPTION
The repository owner needs to add it to <https://travis-ci.org> and <https://coveralls.io>.