### PR TITLE
Fix: testing easy way

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,18 @@ def db_instance(app):
         yield db
 
 
+# overwrite the _APP in background to make it point to the test_app
+# to use in every test that calls a function from the monolith/background.py file
+# I want to remember that also /login make a calls to /fetch
+# Thanks to Stefano we need to give background._APP the correct app to work with otherwise calls to
+# fetch_all_runs would use the real app with the real db
+@pytest.fixture
+def background_app(app):
+    from monolith import background
+    background._APP = app
+    yield app
+
+
 # expose a client which is used to send requests to the app
 @pytest.fixture
 def client(app):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -29,10 +29,10 @@ def test_create_same_user(client, db_instance):
 
 # test the login and logout features now the login make a call to celery so we need celery_session_worker
 # tested with only celery_worker but got stuck after the execution of this function
-def test_login_logout(client, celery_session_worker):
+def test_login_logout(client, background_app, celery_session_worker):
     rv = client.post('/create_user',
-                         data=dict(submit='Publish', email='email', firstname='a', lastname='a', password='p', age='1',
-                                   weight='1', max_hr='1', rest_hr='1', vo2max='1', ), follow_redirects=True)
+                     data=dict(submit='Publish', email='email', firstname='a', lastname='a', password='p', age='1',
+                               weight='1', max_hr='1', rest_hr='1', vo2max='1', ), follow_redirects=True)
     assert rv.data.decode('ascii').count('a a') == 1
 
     rv = client.post('/login', data=dict(email='email', password='p'), follow_redirects=True)
@@ -46,7 +46,7 @@ def test_login_logout(client, celery_session_worker):
 
 
 # this is the interesting one test the /fetch with fake token and fake response
-def test_create_runs(client, app, db_instance, celery_session_worker):
+def test_create_runs(client, background_app, db_instance, celery_session_worker):
     """
 
     we use client app and db_instance celery_worker creates a celery worker instance for this test so we don't need to
@@ -69,24 +69,19 @@ def test_create_runs(client, app, db_instance, celery_session_worker):
         mocked.return_value.exchange_code_for_token.return_value = "blablabla"
         # create an user with email
         rv = client.post('/create_user',
-                             data=dict(submit='Publish', email='email', firstname='a', lastname='a', password='p',
-                                       age='1',
-                                       weight='1', max_hr='1', rest_hr='1', vo2max='1', ), follow_redirects=True)
+                         data=dict(submit='Publish', email='email', firstname='a', lastname='a', password='p',
+                                   age='1',
+                                   weight='1', max_hr='1', rest_hr='1', vo2max='1', ), follow_redirects=True)
         assert rv.data.decode('ascii').count('a a') == 1
         # create an user with emaill
         rv = client.post('/create_user',
-                             data=dict(submit='Publish', email='emaill', firstname='a', lastname='a', password='p',
-                                       age='1',
-                                       weight='1', max_hr='1', rest_hr='1', vo2max='1', ), follow_redirects=True)
+                         data=dict(submit='Publish', email='emaill', firstname='a', lastname='a', password='p',
+                                   age='1',
+                                   weight='1', max_hr='1', rest_hr='1', vo2max='1', ), follow_redirects=True)
 
         rv = client.post('/login', data=dict(email='email', password='p'), follow_redirects=True)
         assert b'Hi email!' in rv.data
         assert b'Authorize Strava Access' in rv.data
-
-        from monolith import background
-        background._APP = app
-        # Thanks to Stefano we need to give background._APP the correct app to work with otherwise calls to
-        # fetch_all_runs would use the real app with the real db
 
         """
             Alright calling mocked_result from conftest.py
@@ -255,7 +250,7 @@ def test_create_runs(client, app, db_instance, celery_session_worker):
             "total_elevation_gain": 0,
             "type": "Run",
             "workout_type": None,
-            "id": 15450425037682, # changed id
+            "id": 15450425037682,  # changed id
             "external_id": "garmin_push_12345678987654321",
             "upload_id": 987654321234567891234,
             "start_date": "2018-05-02T12:15:09Z",
@@ -314,7 +309,7 @@ def test_create_runs(client, app, db_instance, celery_session_worker):
             "total_elevation_gain": 0,
             "type": "Run",
             "workout_type": None,
-            "id": 123456780, # changed id
+            "id": 123456780,  # changed id
             "external_id": "garmin_push_12345678987654321",
             "upload_id": 1234567819,
             "start_date": "2018-04-30T12:35:51Z",


### PR DESCRIPTION
# We already start to see that testing is not easy 😭 😭 

## Problem 🙅‍♂️ 🙅 
I've noticed that if I remove the real database and run ` $ pytest` the database would have been recreated
you can test this simply deleting the `beepbeep.db` instance and you will see that after pytest it will reappear

## Cause 👎 👎 

This behavior was caused by the `_APP` in `monolith/background.py` which is initialized as

````python
     _APP = None
...
def create_context():
    global _APP
    # lazy init
    print(_APP) #for testing shows what kind of app we use
    if _APP is None:
        from monolith.app import create_app
        app = create_app()
        db.init_app(app)
        _APP = app
    else:
        app = _APP
    return app
...
````

So if not set creates a new instance of the real app which would create a new database if it was not present.

## Solution 👍 👍 

The solution is pretty simple actualy in a test just use

````python
def test_example(app):
...
    from monolith import background
        background._APP = app
...
````

But this should be done before and in every test that makes a call to fetch the runs for an user, and as a reminder even `/login` does so. basically in every test...

## Real Solution 🎉 🎉 

`conftest.py` has been updated with a new fixture called `background_app`  which makes the 2 lines of code mentioned above, but you don't have to think where to put those lines of code anymore, just create a test like this

````python
def test_example(background_app):
...
````

And everything will work.

You can test that no real app is ever used deleting the real database running `$ pytest` and checking that no database is created after the test
